### PR TITLE
(feat & chore: 게시판 Entity&DTO 생성 및 CRUD 기능 추가, build 시 서브모듈의 application.yml 자동 복사)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,11 @@ configurations {
 		extendsFrom annotationProcessor
 	}
 }
+//
+//task copySecret(type: Copy) {
+//	from './config-submodule/application.yml' // 서브모듈에 있는 application.yml 설정파일을 복사한다.
+//	into 'src/main/resources'
+//}
 
 repositories {
 	mavenCentral()
@@ -27,12 +32,14 @@ dependencies {
 
 	// JWT
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+	testImplementation 'junit:junit:4.13.1'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/petgoorm/backend/controller/BoardController.java
+++ b/src/main/java/com/petgoorm/backend/controller/BoardController.java
@@ -1,0 +1,57 @@
+package com.petgoorm.backend.controller;
+
+import com.petgoorm.backend.dto.ResponseDTO;
+import com.petgoorm.backend.dto.board.BoardRequestDTO;
+import com.petgoorm.backend.dto.board.BoardResponseDTO;
+import com.petgoorm.backend.service.BoardService;
+import com.petgoorm.backend.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/board")
+public class BoardController {
+    private final BoardService boardService;
+
+    // 글 등록
+    @PostMapping("/create")
+    public ResponseDTO<Long> create (@RequestBody BoardRequestDTO boardRequestDTO, @RequestHeader("Authorization") String accessToken) {
+        String tokenWithoutBearer = accessToken.replace("Bearer ", "");
+        return boardService.create(boardRequestDTO,tokenWithoutBearer);
+    }
+
+    //글 조회
+    @GetMapping("/{boardId}")
+    public ResponseDTO<BoardResponseDTO> getBoard(@PathVariable Long boardId) {
+        return boardService.findOneBoard(boardId);
+    }
+
+    // 글 삭제
+    @DeleteMapping ("/delete/{boardId}")
+    public ResponseDTO<String> delete (@PathVariable Long boardId, @RequestHeader("Authorization") String accessToken){
+        String tokenWithoutBearer = accessToken.replace("Bearer ", "");
+        return boardService.delete(boardId,tokenWithoutBearer);
+    }
+
+    // 글 수정
+    @GetMapping("/{boardId}/edit")
+    public ResponseDTO<BoardResponseDTO.edit> editForm(@PathVariable Long boardId, @RequestHeader("Authorization") String accessToken) {
+        String tokenWithoutBearer = accessToken.replace("Bearer ", "");
+        return boardService.updateGet(boardId,tokenWithoutBearer);
+    }
+
+    @PutMapping("/{boardId}/edit")
+    public ResponseDTO<Long> edit(@PathVariable Long boardId, @Valid @RequestBody BoardRequestDTO.edit EditForm, BindingResult bindingResult, @RequestHeader("Authorization") String accessToken) {
+        String tokenWithoutBearer = accessToken.replace("Bearer ", "");
+        return boardService.updatePut(boardId, EditForm, tokenWithoutBearer);
+    }
+
+
+}

--- a/src/main/java/com/petgoorm/backend/dto/board/BoardRequestDTO.java
+++ b/src/main/java/com/petgoorm/backend/dto/board/BoardRequestDTO.java
@@ -1,0 +1,34 @@
+package com.petgoorm.backend.dto.board;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+
+
+
+@Data
+@RequiredArgsConstructor
+@Builder
+@AllArgsConstructor
+public class BoardRequestDTO {
+
+
+                private String title;
+                private String content;
+                private String category;
+                private String image;
+                private String writerNickname;
+                private String writerAddress;
+
+                @Data
+                @Builder
+                @AllArgsConstructor
+                public static class edit {
+                    private String title;
+                    private String content;
+                    private String category;
+                    private String image;
+
+                }
+        }
+

--- a/src/main/java/com/petgoorm/backend/dto/board/BoardResponseDTO.java
+++ b/src/main/java/com/petgoorm/backend/dto/board/BoardResponseDTO.java
@@ -1,0 +1,43 @@
+package com.petgoorm.backend.dto.board;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+@RequiredArgsConstructor
+@Builder
+@AllArgsConstructor
+public class BoardResponseDTO {
+
+    @NotBlank
+    private Long boardId;
+    @NotBlank
+    private String title;
+    @NotBlank
+    private String content;
+    @NotBlank
+    private String category;
+    private String image;
+    private String writerNickname;
+    private String writerLocation;
+
+    @Data
+    @RequiredArgsConstructor
+    @Builder
+    @AllArgsConstructor
+    public static class edit{
+        @NotBlank
+        private String title;
+        @NotBlank
+        private String content;
+        @NotBlank
+        private String category;
+        private String image;
+    }
+
+
+}

--- a/src/main/java/com/petgoorm/backend/entity/Board.java
+++ b/src/main/java/com/petgoorm/backend/entity/Board.java
@@ -1,0 +1,56 @@
+package com.petgoorm.backend.entity;
+
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name="board")
+@Data
+@AllArgsConstructor
+@Builder
+@RequiredArgsConstructor
+@DynamicInsert
+public class Board extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long boardId;
+
+    @Column(name = "title",nullable = false)
+    private String title;
+
+    @Column(name = "content",nullable = false)
+    private String content;
+
+    @Column(name = "image")
+    private String image;
+
+    @Column(name = "category")
+    private String category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member writer;
+
+    @Column(name = "writer_address",nullable = false)
+    private String writerAddress;
+
+    @Column(name = "writer_nickname",nullable = false)
+    private String writerNickname;
+
+    @Column(name = "click_cnt",nullable = false)
+    @ColumnDefault("0")
+    private Long clickCnt;
+
+    @Column(name = "likes_cnt",nullable = false)
+    @ColumnDefault("0")
+    private Long likesCnt;
+
+    @Column(name = "comment_cnt",nullable = false)
+    @ColumnDefault("0")
+    private Long commentCnt;
+
+}

--- a/src/main/java/com/petgoorm/backend/repository/BoardRepository.java
+++ b/src/main/java/com/petgoorm/backend/repository/BoardRepository.java
@@ -1,0 +1,10 @@
+package com.petgoorm.backend.repository;
+
+import com.petgoorm.backend.entity.Board;
+import com.petgoorm.backend.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/src/main/java/com/petgoorm/backend/service/BoardService.java
+++ b/src/main/java/com/petgoorm/backend/service/BoardService.java
@@ -1,0 +1,66 @@
+package com.petgoorm.backend.service;
+
+import com.petgoorm.backend.dto.ResponseDTO;
+import com.petgoorm.backend.dto.board.BoardRequestDTO;
+import com.petgoorm.backend.dto.board.BoardResponseDTO;
+import com.petgoorm.backend.entity.Board;
+import com.petgoorm.backend.entity.Member;
+
+
+public interface BoardService {
+
+
+    public ResponseDTO<Long> create(BoardRequestDTO boardRequestDTO,String accessToken);
+    public ResponseDTO<String> delete(Long boardId, String accessToken);
+
+    public ResponseDTO<BoardResponseDTO> findOneBoard(Long boardId);
+    public ResponseDTO<BoardResponseDTO.edit> updateGet(Long boardId, String accessToken);
+    public ResponseDTO<Long> updatePut(Long boardId, BoardRequestDTO.edit boardDTO, String accessToken);
+
+    public default Board createToEntity(BoardRequestDTO dto, Member member) {
+
+        Board board = Board.builder()
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .image(dto.getImage())
+                .category(dto.getCategory())
+                .writer(member)
+                .writerAddress(member.getAddress())
+                .writerNickname(member.getNickname())
+                .build();
+        return board;
+    }
+
+    public default BoardResponseDTO toDTO(Board board) {
+        BoardResponseDTO dto = new BoardResponseDTO();
+        dto.setTitle(board.getTitle());
+        dto.setContent(board.getContent());
+        dto.setImage(board.getImage());
+        dto.setWriterNickname(board.getWriterNickname());
+        //주소에 특정 부분만 잘라서 dto에 담음 - 추후 더 정교하게 지역 나눌 예정
+        dto.setWriterLocation(board.getWriterAddress().replaceAll("\\\"","").trim());
+        return dto;
+    }
+
+
+    //수정 - get board form
+    public default BoardResponseDTO.edit createEditForm(Board board) {
+        return BoardResponseDTO.edit.builder()
+                .title(board.getTitle())
+                .content(board.getContent())
+                .image(board.getImage())
+                .category(board.getCategory())
+                .build();
+    }
+
+
+    //수정 - put board form
+    public default Board updateBoard(Board board, BoardRequestDTO.edit editForm) {
+        board.setTitle(editForm.getTitle());
+        board.setContent(editForm.getContent());
+        board.setCategory(editForm.getCategory());
+        board.setImage(editForm.getImage());
+        return board;
+    }
+
+}

--- a/src/main/java/com/petgoorm/backend/service/BoardServiceImpl.java
+++ b/src/main/java/com/petgoorm/backend/service/BoardServiceImpl.java
@@ -1,0 +1,149 @@
+package com.petgoorm.backend.service;
+
+import com.petgoorm.backend.dto.ResponseDTO;
+import com.petgoorm.backend.dto.board.BoardRequestDTO;
+import com.petgoorm.backend.dto.board.BoardResponseDTO;
+import com.petgoorm.backend.entity.Board;
+import com.petgoorm.backend.entity.Member;
+import com.petgoorm.backend.jwt.JwtTokenProvider;
+import com.petgoorm.backend.repository.BoardRepository;
+import com.petgoorm.backend.repository.MemberRepository;
+import com.petgoorm.backend.util.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+
+@Service
+@Log4j2
+@Transactional
+@RequiredArgsConstructor
+public class BoardServiceImpl implements BoardService {
+
+    final private BoardRepository boardRepository;
+
+    final private MemberRepository memberRepository;
+
+    final private JwtTokenProvider jwtTokenProvider;
+
+
+    // 회원 인증 여부를 확인하는 서비스 내부 메서드
+    private Member getAuthenticatedMember(String tokenWithoutBearer) {
+        Authentication userDetails = jwtTokenProvider.getAuthentication(tokenWithoutBearer);
+        if (userDetails == null) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "로그인 상태를 확인 해 주세요.");
+        }
+        String email = userDetails.getName();
+
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."));
+    }
+
+    //board 조회 시 null인지 확인하는 내부 메서드
+    private ResponseDTO<Optional<Board>> optionalBoard(Long boardId) {
+        Optional<Board> optionalBoard = boardRepository.findById(boardId);
+
+        if (optionalBoard.isEmpty()) {
+            return ResponseDTO.of(HttpStatus.NOT_FOUND.value(), "게시물 정보를 찾을 수 없습니다.", null);
+        }
+        return ResponseDTO.of(HttpStatus.OK.value(), null, optionalBoard);
+    }
+
+
+    //글 등록 => boardId 반환
+    @Override
+    @Transactional
+    public ResponseDTO<Long> create(BoardRequestDTO boardDTO, String tokenWithoutBearer) {
+        Member member = getAuthenticatedMember(tokenWithoutBearer);
+        Board board = createToEntity(boardDTO, member);
+        try {
+            boardRepository.save(board);
+            return ResponseDTO.of(HttpStatus.OK.value(), "게시물 작성이 완료되었습니다.", board.getBoardId());
+        } catch (Exception e) {
+            return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
+        }
+    }
+
+    //게시물 삭제
+    @Override
+    @Transactional
+    public ResponseDTO<String> delete(Long boardId, String tokenWithoutBearer) {
+        Member member = getAuthenticatedMember(tokenWithoutBearer);
+        Optional<Board> optionalBoard = optionalBoard(boardId).getData();
+
+        Board board = optionalBoard.get();
+        if (!board.getWriter().getId().equals(member.getId())) {
+            return ResponseDTO.of(HttpStatus.FORBIDDEN.value(), "게시물 삭제 권한이 없습니다.", null);
+        }
+        try {
+            boardRepository.deleteById(boardId);
+            return ResponseDTO.of(HttpStatus.OK.value(), "게시물이 삭제되었습니다.", null);
+        } catch (Exception e) {
+            return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
+        }
+    }
+
+
+    //글 조회
+    @Override
+    @Transactional
+    public ResponseDTO<BoardResponseDTO> findOneBoard(Long boardId) {
+
+        Optional<Board> optionalBoard = optionalBoard(boardId).getData();
+
+        try {
+            Board board = optionalBoard.get();
+            BoardResponseDTO boardResponseDTO = toDTO(board);
+            return ResponseDTO.of(HttpStatus.OK.value(), null, boardResponseDTO);
+        } catch (Exception e) {
+            return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
+        }
+    }
+
+    @Override
+    @Transactional
+    public ResponseDTO<BoardResponseDTO.edit> updateGet(Long boardId, String tokenWithoutBearer) {
+        Member member = getAuthenticatedMember(tokenWithoutBearer);
+        Optional<Board> optionalBoard = optionalBoard(boardId).getData();
+
+        Board board = optionalBoard.get();
+        boolean check = board.getWriter().getId().equals(member.getId());
+
+        if (!check) {
+            return ResponseDTO.of(HttpStatus.FORBIDDEN.value(), "게시물 수정 권한이 없습니다.", null);
+        }
+
+        BoardResponseDTO.edit editForm = createEditForm(board);
+
+        return ResponseDTO.of(HttpStatus.OK.value(), null, editForm);
+    }
+
+    @Override
+    @Transactional
+    public ResponseDTO<Long> updatePut(Long boardId, BoardRequestDTO.edit editForm, String tokenWithoutBearer) {
+        Member member = getAuthenticatedMember(tokenWithoutBearer);
+        Optional<Board> optionalBoard = optionalBoard(boardId).getData();
+
+        Board board = optionalBoard.get();
+        boolean check = board.getWriter().getId().equals(member.getId());
+
+        if (!check) {
+            return ResponseDTO.of(HttpStatus.FORBIDDEN.value(), "게시물 수정 권한이 없습니다.", null);
+        }
+
+        updateBoard(board, editForm);
+
+        return ResponseDTO.of(HttpStatus.OK.value(), "게시물이 수정되었습니다.", board.getBoardId());
+    }
+
+
+}
+
+
+
+


### PR DESCRIPTION
[Board 엔티티]
- Member 엔티티와 1:M의 관계차수를 가지고 있으므로 Board는 fetch.Lazy 방식으로 Member를 참조합니다.
[Board DTO]
- 기본적으로 Req, Res 두가지 클래스로 나누어 두었으며, edit 기능 수행시에만 데이터 구조가 다르므로 DTO 내부 클래스를 생성해 두었습니다.
[CRUD 기능]
- JWT 토큰으로 게시물 생성, 수정, 삭제 시도 시 회원의 정보 및 권한을 확인합니다.
[serviceImpl 내부 메서드]
- 회원 인증정보를 확인하는 기능
- Board 조회시 null을 확인하는 기능
=> 두 기능이 CRUD 수행 시 중첩되는 경향이 있으므로, 내부 메서드로 분리해두었습니다.
[백엔드 build 시 서브모듈 복사작업 수행]
- 빌드 시 서브모듈의 application.yml 파일을 자동으로 프로젝트에 복사하는 코드를 추가했습니다. 