### PR TITLE
(feat: 마이페이지 기능, 펫 관리 기능 추가)

### DIFF
--- a/src/main/java/com/petgoorm/backend/controller/MemberController.java
+++ b/src/main/java/com/petgoorm/backend/controller/MemberController.java
@@ -41,6 +41,12 @@ public class MemberController {
         return memberService.login(login);
     }
 
+    @PostMapping("/reissue")
+    public ResponseDTO<String> reissue(@RequestHeader("Authorization") String accessToken) {
+        String tokenWithoutBearer = accessToken.replace("Bearer ", "");
+        return memberService.reissue(tokenWithoutBearer);
+    }
+
     @PostMapping("/logout")
     public ResponseDTO<String> logout(@RequestHeader("Authorization") String accessToken) {
         String tokenWithoutBearer = accessToken.replace("Bearer ", "");

--- a/src/main/java/com/petgoorm/backend/controller/MemberController.java
+++ b/src/main/java/com/petgoorm/backend/controller/MemberController.java
@@ -53,6 +53,23 @@ public class MemberController {
         return memberService.logout(tokenWithoutBearer);
     }
 
+    @PatchMapping("/editpw")
+    public ResponseDTO<Long> updatePassword(@RequestBody MemberRequestDTO.UpdatePassword updatePassword){
+        return memberService.updatePassword(updatePassword);
+
+    }
+    @PatchMapping("/editnick")
+    public ResponseDTO<Long> updateNick(@RequestBody MemberRequestDTO.UpdateNick updateNick){
+        return memberService.updateNick(updateNick);
+
+    }
+    @DeleteMapping("/remove")
+    public ResponseDTO<Long> delete(){
+        return memberService.deleteMember();
+    }
+
+
+
 
 
 }

--- a/src/main/java/com/petgoorm/backend/controller/PetController.java
+++ b/src/main/java/com/petgoorm/backend/controller/PetController.java
@@ -27,7 +27,14 @@ public class PetController {
         return petService.petInfo();
     }
 
+    @PutMapping("/edit/{petId}")
+    public ResponseDTO<PetDTO> update(@PathVariable Long petId, @RequestBody PetDTO petDTO){
+        return petService.updatePet(petId, petDTO);
+    }
 
-
+    @DeleteMapping("/remove/{petId}")
+    public ResponseDTO<Long> delete(@PathVariable Long petId){
+        return petService.deletePet(petId);
+    }
 
 }

--- a/src/main/java/com/petgoorm/backend/dto/member/MemberRequestDTO.java
+++ b/src/main/java/com/petgoorm/backend/dto/member/MemberRequestDTO.java
@@ -43,4 +43,21 @@ public class MemberRequestDTO {
         }
     }
 
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class UpdatePassword{
+        private String nowPW;
+        private String updatePW;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateNick{
+        private String nickname;
+    }
+
 }

--- a/src/main/java/com/petgoorm/backend/entity/Member.java
+++ b/src/main/java/com/petgoorm/backend/entity/Member.java
@@ -91,4 +91,14 @@ public class Member extends BaseEntity implements UserDetails {
     public boolean isEnabled() {
         return false;
     }
+
+    //패스워드 변경 메서드
+    public void updatePassword(String updatePW){
+        this.password = updatePW;
+    }
+    //닉네임 변경 메서드
+    public void updateNick(String updateNick){
+        this.nickname = updateNick;
+    }
+
 }

--- a/src/main/java/com/petgoorm/backend/entity/Pet.java
+++ b/src/main/java/com/petgoorm/backend/entity/Pet.java
@@ -1,5 +1,6 @@
 package com.petgoorm.backend.entity;
 
+import com.petgoorm.backend.dto.pet.PetDTO;
 import lombok.*;
 
 import javax.persistence.*;
@@ -44,5 +45,15 @@ public class Pet extends BaseEntity{
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false, name="member_id")
     private Member member;
+
+    public void UpdatePet(PetDTO petDTO) {
+        this.petUrl = petDTO.getPetUrl();
+        this.age = petDTO.getAge();
+        this.birth = petDTO.getBirth();
+        this.firstmet = petDTO.getFirstmet();
+        this.petname = petDTO.getPetname();
+        this.type = petDTO.getType();
+        this.weight = petDTO.getWeight();
+    }
 
 }

--- a/src/main/java/com/petgoorm/backend/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/petgoorm/backend/jwt/JwtTokenProvider.java
@@ -38,6 +38,26 @@ public class JwtTokenProvider {
 
     // 유저 정보를 가지고 AccessToken, RefreshToken 을 생성하는 메서드
     public MemberResponseDTO.TokenInfo generateToken(Authentication authentication) {
+
+        String accessToken = accessToken(authentication);
+        long now = (new Date()).getTime();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return MemberResponseDTO.TokenInfo.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .refreshTokenExpirationTime(REFRESH_TOKEN_EXPIRE_TIME)
+                .build();
+    }
+
+    // refreshtoken이 유효할때 AccessToken 을 생성하는 메서드
+    public String accessToken(Authentication authentication) {
         // 권한 가져오기
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
@@ -53,19 +73,9 @@ public class JwtTokenProvider {
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 
-        // Refresh Token 생성
-        String refreshToken = Jwts.builder()
-                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
-
-        return MemberResponseDTO.TokenInfo.builder()
-                .grantType(BEARER_TYPE)
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .refreshTokenExpirationTime(REFRESH_TOKEN_EXPIRE_TIME)
-                .build();
+        return accessToken;
     }
+
 
     // JWT 토큰을 복호화하여 토큰에 들어있는 정보를 꺼내는 메서드
     public Authentication getAuthentication(String accessToken) {

--- a/src/main/java/com/petgoorm/backend/repository/MemberRepository.java
+++ b/src/main/java/com/petgoorm/backend/repository/MemberRepository.java
@@ -10,8 +10,10 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    Optional<Member> deleteMemberByEmail(String email);
 
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
+
 
 }

--- a/src/main/java/com/petgoorm/backend/repository/PetRepository.java
+++ b/src/main/java/com/petgoorm/backend/repository/PetRepository.java
@@ -11,6 +11,8 @@ import java.util.Optional;
 public interface PetRepository extends JpaRepository<Pet, Long> {
 
     Optional<Pet> findByMember(Member member);
-
+    Optional<Pet> findById(Long petId);
+    Optional<Pet> deletePetByPetId(Long petId);
+    Optional<Pet> deletePetByMemberId(Long memberId);
 
 }

--- a/src/main/java/com/petgoorm/backend/service/MemberService.java
+++ b/src/main/java/com/petgoorm/backend/service/MemberService.java
@@ -40,5 +40,8 @@ public interface MemberService {
 
     ResponseDTO<MemberResponseDTO.TokenInfo> login(MemberRequestDTO.Login login);
 
+    //refresh token 유효성 검증 후 access token 재발급
+    ResponseDTO<String> reissue(String nowAccessToken);
+
     ResponseDTO<String> logout(String accessToken);
 }

--- a/src/main/java/com/petgoorm/backend/service/MemberService.java
+++ b/src/main/java/com/petgoorm/backend/service/MemberService.java
@@ -44,4 +44,12 @@ public interface MemberService {
     ResponseDTO<String> reissue(String nowAccessToken);
 
     ResponseDTO<String> logout(String accessToken);
+
+    ResponseDTO<Long> updatePassword(MemberRequestDTO.UpdatePassword updatePassword);
+
+    ResponseDTO<Long> updateNick(MemberRequestDTO.UpdateNick updateNick);
+
+    ResponseDTO<Long> deleteMember();
+
+
 }

--- a/src/main/java/com/petgoorm/backend/service/PetService.java
+++ b/src/main/java/com/petgoorm/backend/service/PetService.java
@@ -41,4 +41,8 @@ public interface PetService {
     ResponseDTO<Long> petAdd(PetDTO petDTO);
 
     ResponseDTO<PetDTO> petInfo();
+
+    ResponseDTO<PetDTO> updatePet(Long petId, PetDTO petDTO);
+
+    ResponseDTO<Long> deletePet(Long petId);
 }

--- a/src/main/java/com/petgoorm/backend/service/PetServiceImpl.java
+++ b/src/main/java/com/petgoorm/backend/service/PetServiceImpl.java
@@ -53,7 +53,7 @@ public class PetServiceImpl implements PetService {
         Pet pet = petRepository.findByMember(member).orElseThrow(()-> new NullPointerException("펫이 존재하지 않습니다."));
         try{
             PetDTO petDTO = toDTO(pet);
-            return ResponseDTO.of(HttpStatus.OK.value(), "펫 등록에 성공했습니다.", petDTO);
+            return ResponseDTO.of(HttpStatus.OK.value(), "펫 정보 조회에 성공했습니다.", petDTO);
 
         }catch (Exception e){
             return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
@@ -61,6 +61,49 @@ public class PetServiceImpl implements PetService {
         }
 
     }
+
+    @Transactional
+    @Override
+    public ResponseDTO<PetDTO> updatePet(Long petId, PetDTO petDTO){
+
+        try {
+
+            Pet pet = petRepository.findById(petId).orElseThrow(() -> new NullPointerException("펫이 존재하지 않습니다."));
+
+            //더티체킹(save 불필요)
+            pet.UpdatePet(petDTO);
+
+            log.info("pet " + pet);
+            return ResponseDTO.of(HttpStatus.OK.value(), "펫 수정에 성공했습니다.", null);
+
+        }
+        catch (Exception e){
+            return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
+
+        }
+
+
+    }
+
+    //펫 삭제 서비스
+    @Transactional
+    @Override
+    public ResponseDTO<Long> deletePet(Long petId){
+
+        try {
+            petRepository.deletePetByPetId(petId);
+            return ResponseDTO.of(HttpStatus.OK.value(), "펫 삭제에 성공했습니다.", petId);
+        }
+        catch (Exception e){
+            return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
+
+        }
+
+
+    }
+
+
+
 
 
 }

--- a/src/test/java/com/petgoorm/backend/MemberTests.java
+++ b/src/test/java/com/petgoorm/backend/MemberTests.java
@@ -1,0 +1,77 @@
+package com.petgoorm.backend;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petgoorm.backend.dto.member.MemberRequestDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class MemberTests {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+    @Test
+    @DisplayName("비밀번호 변경 컨트롤러 테스트")
+    @WithUserDetails(value="test0524@naver.com")
+    public void updatePassword() throws Exception {
+
+        MemberRequestDTO.UpdatePassword updatePasswordDTO = MemberRequestDTO.UpdatePassword.builder()
+                .nowPW("qwer1234")
+                .updatePW("qqqq1111")
+                .build();
+
+        mockMvc.perform(patch("/member/editpw")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatePasswordDTO)
+                        ))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 컨트롤러 테스트")
+    @WithUserDetails(value="test0524@naver.com")
+    public void updateNick() throws Exception {
+
+        MemberRequestDTO.UpdateNick updateNick = MemberRequestDTO.UpdateNick.builder().nickname("테스트0627").build();
+
+        mockMvc.perform(patch("/member/editnick")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateNick)
+                        ))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+    @Test
+    @DisplayName("회원 삭제 컨트롤러 테스트")
+    @WithMockUser(username = "bys@naver.com", roles = {"USER"})
+    public void delete() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/member/remove"))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+
+    }
+
+
+
+
+
+}

--- a/src/test/java/com/petgoorm/backend/PetTests.java
+++ b/src/test/java/com/petgoorm/backend/PetTests.java
@@ -1,14 +1,37 @@
 package com.petgoorm.backend;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petgoorm.backend.dto.pet.PetDTO;
 import com.petgoorm.backend.util.SecurityUtil;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 public class PetTests {
+
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
 
     @Test
     public void nowEmail(){
@@ -24,6 +47,39 @@ public class PetTests {
 
         System.out.println(SecurityUtil.getCurrentUserEmail());
     }
+
+    @Test
+    @DisplayName("펫 수정 컨트롤러 테스트")
+    @WithMockUser(username = "testUser", roles = {"USER"})
+    public void update() throws Exception {
+
+        PetDTO petDTO = PetDTO.builder()
+                .petname("하이")
+                .build();
+
+        mockMvc.perform(put("/pet/edit/{petId}", 2)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(petDTO)
+                                ))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+
+    }
+
+    @Test
+    @DisplayName("펫 삭제 컨트롤러 테스트")
+    @WithMockUser(username = "testUser", roles = {"USER"})
+    public void delete() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/pet/remove/{petId}", 2))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+
+    }
+
+
 
 
 }


### PR DESCRIPTION
- 사용자의 닉네임 변경, 비밀번호 변경, 회원 탈퇴 기능 추가하였습니다.
- 펫 정보 수정 기능, 펫 삭제 기능 추가하였습니다.
- access token이 만료됐을 시 refresh token을 체크하여 유효한 토큰일 경우 access token을 새로 발급하여 
  사용자에게 다시 건네주도록 하였습니다.
- mockMVC를 사용하여 controller api 테스트를 진행하였습니다. 이때 withmockuser와 withuserdetails를 사용하여 가상의 사용자 혹은 db에 저장되어 있는 유저 이메일을 통해 인증기능을 패스하였습니다.