### PR TITLE
(feat: 에러 핸들링 기능 추가)

### DIFF
--- a/src/main/java/com/petgoorm/backend/config/WebSecurityConfig.java
+++ b/src/main/java/com/petgoorm/backend/config/WebSecurityConfig.java
@@ -1,5 +1,7 @@
 package com.petgoorm.backend.config;
 
+import com.petgoorm.backend.handler.CustomAccessDeniedHandler;
+import com.petgoorm.backend.handler.CustomAuthenticationEntryPoint;
 import com.petgoorm.backend.jwt.JwtAuthenticationFilter;
 import com.petgoorm.backend.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -41,13 +43,16 @@ public class WebSecurityConfig {
                 .csrf().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .authorizeRequests()
-                .antMatchers("/member/login", "/member/signup").permitAll() // 로그인과 회원가입은 인증 없이 접근 가능
-                .anyRequest().authenticated()
+                //인증 인가 exception 핸들링
+                // (인증 인가에서 에러가 발생할 시 무조건 아래 클래스들을 거쳐서 클라이언트에 response가 반환됨)
+                .exceptionHandling()
+                .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                .accessDeniedHandler(new CustomAccessDeniedHandler())
                 .and()
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate), UsernamePasswordAuthenticationFilter.class);
-        // JwtAuthenticationFilter를 UsernamePasswordAuthentictaionFilter 전에 적용시킨다.
-
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, redisTemplate), UsernamePasswordAuthenticationFilter.class)
+                .authorizeRequests()
+                .antMatchers("/member/login", "/member/signup","/member/checkEmail","/member/checkNick","/member/reissue").permitAll() // 로그인과 회원가입은 인증 없이 접근 가능
+                .anyRequest().authenticated();
 
         return http.build();
     }

--- a/src/main/java/com/petgoorm/backend/dto/ResponseDTO.java
+++ b/src/main/java/com/petgoorm/backend/dto/ResponseDTO.java
@@ -1,10 +1,13 @@
 package com.petgoorm.backend.dto;
 
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
 @Data
+//of를 사용하여 값을 집어넣으니까 코드를 한눈에 파악하기 어려워서 빌더 패턴도 추가함
+@Builder
 @RequiredArgsConstructor(staticName = "of")
 //공통 응답 DTO
 public class ResponseDTO<T> {

--- a/src/main/java/com/petgoorm/backend/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/petgoorm/backend/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package com.petgoorm.backend.handler;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petgoorm.backend.dto.ResponseDTO;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+//권한이 없는 사용자가 접근할 시 에러(인가 에러- security 필터 단)
+@Component
+@Log4j2
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, AccessDeniedException e)
+            throws IOException, ServletException {
+        ResponseDTO responseDTO = ResponseDTO.of(HttpStatus.FORBIDDEN.value(), "Forbidden",null);
+
+        String result = objectMapper.writeValueAsString(responseDTO);
+        log.info("CustomAuthenticationEntryPoint: 인가 예외 발생");
+        httpServletResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        httpServletResponse.setStatus(HttpStatus.FORBIDDEN.value());
+        httpServletResponse.getWriter().write(result);
+        httpServletResponse.getWriter().flush();
+    }
+}

--- a/src/main/java/com/petgoorm/backend/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/petgoorm/backend/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.petgoorm.backend.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petgoorm.backend.dto.ResponseDTO;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+//인증이 되지않은 사용자가 접근시 에러(security 필터단에서 발생한 인증 에러 가로채 핸들링)
+@Log4j2
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, AuthenticationException e)
+            throws IOException, ServletException {
+        String exception = (String) httpServletRequest.getAttribute("exception");
+        ResponseDTO responseDTO = ResponseDTO.of(HttpStatus.UNAUTHORIZED.value(), "UNAUTHORIZED",null);
+
+        String result = objectMapper.writeValueAsString(responseDTO);
+        log.info("CustomAuthenticationEntryPoint: 인증 예외 발생");
+        httpServletResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);;
+        httpServletResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
+        httpServletResponse.getWriter().write(result);
+        httpServletResponse.getWriter().flush();
+    }
+}

--- a/src/main/java/com/petgoorm/backend/handler/CustomException.java
+++ b/src/main/java/com/petgoorm/backend/handler/CustomException.java
@@ -1,0 +1,16 @@
+package com.petgoorm.backend.handler;
+
+import com.petgoorm.backend.handler.ErrorCode;
+import lombok.Getter;
+
+
+@Getter
+//어떤 에런지 파라미터로 받으면서 기본생성자에 등록
+public class CustomException extends RuntimeException {
+    private ErrorCode error;
+
+    public CustomException(ErrorCode e) {
+        super(e.getMessage());
+        this.error = e;
+    }
+}

--- a/src/main/java/com/petgoorm/backend/handler/ErrorCode.java
+++ b/src/main/java/com/petgoorm/backend/handler/ErrorCode.java
@@ -1,0 +1,41 @@
+package com.petgoorm.backend.handler;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    //4번째에 있는 숫자 에러코드 말고 string 으로 된 2번쨰 에러코드를 사용하고 싶었지만
+    //기존에 클라이언트로 보내는 모든 에러코드가 int형식이라 우선은 4번째 숫자 에러코드를 클라이언트에 반환함
+    //리팩토링 할때 string 형식으로 고치거나 숫자 에러코드를 계속 사용하면 될 것 같음
+
+    // Member
+    NOT_FOUND_MEMBER(HttpStatus.BAD_REQUEST,"MEMBER-0001", "Member not found",1001),
+    EXISTING_MEMBER(HttpStatus.BAD_REQUEST, "MEMBER-0002", "Member that already exists",1002),
+
+    // Post
+    NOT_FOUND_POST(HttpStatus.BAD_REQUEST, "POST-0001", "Post not found",2001),
+
+    // File
+    AWS_S3_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, "FILE-0001", "AWS S3 File upload fail",3001),
+    AWS_S3_UPLOAD_VALID(HttpStatus.BAD_REQUEST, "FILE-0002", "File validation",3002),
+
+    // Role
+    NOT_HAVE_PERMISSION(HttpStatus.BAD_REQUEST, "ROLE-0001", "You do not have permission",4001),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "ROLE-0002", "Unauthorized",4002),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "ROLE-0003", "Forbidden",4003),
+
+    //JWT
+    JWT_ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN-0001", "Access token has expired",5001),
+    JWT_REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN-0002", "Refresh token has expired",5002);
+
+    HttpStatus status;
+    String code;
+    String message;
+    Integer codeNum;
+
+
+}

--- a/src/main/java/com/petgoorm/backend/handler/ExceptionHandler.java
+++ b/src/main/java/com/petgoorm/backend/handler/ExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.petgoorm.backend.handler;
+
+import com.petgoorm.backend.dto.ResponseDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+// 컨트롤러에서 발생한 exception에러를 가로채 handling하는 역할의 어노테이션
+@RestControllerAdvice
+public class ExceptionHandler {
+
+    @org.springframework.web.bind.annotation.ExceptionHandler({CustomException.class})
+    public ResponseEntity<ResponseDTO> customExceptionHandler(CustomException e) {
+        return ResponseEntity
+                .status(e.getError().getStatus())
+                .body(
+                        ResponseDTO.builder()
+                                .statusCode(e.getError().getCodeNum())
+                                .message(e.getError().getMessage())
+                                .build()
+                );
+    }
+}

--- a/src/main/java/com/petgoorm/backend/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/petgoorm/backend/jwt/JwtAuthenticationFilter.java
@@ -1,25 +1,29 @@
 package com.petgoorm.backend.jwt;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petgoorm.backend.dto.ResponseDTO;
+import com.petgoorm.backend.handler.ErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @Slf4j
 @RequiredArgsConstructor
-public class JwtAuthenticationFilter extends GenericFilterBean {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_TYPE = "Bearer";
@@ -28,22 +32,35 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     private final RedisTemplate redisTemplate;
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
 
-        // 1. Request Header 에서 JWT 토큰 추출
-        String token = resolveToken((HttpServletRequest) request);
+        try {
+            String token = resolveToken(request);
+            String path = request.getServletPath();
+            log.info(path);
+            if (path.startsWith("/member/reissue")) {
+                chain.doFilter(request, response);
+            } else{
+                    if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+                        // (추가) Redis 에 해당 accessToken logout 여부 확인
+                        String isLogout = (String) redisTemplate.opsForValue().get(token);
 
-        // 2. validateToken 으로 토큰 유효성 검사
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            // (추가) Redis 에 해당 accessToken logout 여부 확인
-            String isLogout = (String)redisTemplate.opsForValue().get(token);
-            if (ObjectUtils.isEmpty(isLogout)) {
-                // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext 에 저장
-                Authentication authentication = jwtTokenProvider.getAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
+                        if (ObjectUtils.isEmpty(isLogout)) {
+                            // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext 에 저장
+                            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                        }
+                    }
+
+                    chain.doFilter(request, response);
+                }
+
+        } catch (ExpiredJwtException e) {
+            //토큰의 유효기간 만료시 5001 에러코드 클라이언트에 반환
+            setErrorResponse(response, ErrorCode.JWT_ACCESS_TOKEN_EXPIRED);
         }
-        chain.doFilter(request, response);
+
     }
 
     // Request Header 에서 토큰 정보 추출
@@ -54,4 +71,30 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         }
         return null;
     }
+
+    //filter에서 발생하는 예외는 restcontrolleradvice로 잡을 수 없기때문에 따로 메서드를 생성함
+    //에러코드 커스텀 가능
+    //토큰 유효기간 만료 외의 인증인가 에러는
+    //customaccesssdenidedhandler와 customauthenticationentrypoint클래스에서 핸들링됨
+    private void setErrorResponse(
+            HttpServletResponse response,
+            ErrorCode errorCode
+    ) {
+
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8"); // UTF-8로 인코딩 설정
+
+        ResponseDTO<?> responseDTO = ResponseDTO.of(errorCode.getCodeNum(), errorCode.getMessage(), null);
+
+        try {
+            response.getWriter().write(new ObjectMapper().writeValueAsString(responseDTO));
+            response.getWriter().flush();
+
+            log.info("setErrorResponse: " + responseDTO.getMessage());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
 }

--- a/src/main/java/com/petgoorm/backend/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/petgoorm/backend/jwt/JwtTokenProvider.java
@@ -27,7 +27,7 @@ public class JwtTokenProvider {
 
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 30 * 60 * 1000L;              // 30분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 30 * 10 * 1000L;              // 30분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 7 * 24 * 60 * 60 * 1000L;    // 7일
     private final Key key;
 
@@ -101,11 +101,11 @@ public class JwtTokenProvider {
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            log.info("토큰 검증 성공");
             return true;
+            //이 부분에서 생기는 에러도 CustomAuthentication 클래스에서 핸들링됨
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             log.info("잘못된 JWT 서명입니다.");
-        } catch (ExpiredJwtException e) {
-            log.info("만료된 JWT 토큰입니다.");
         } catch (UnsupportedJwtException e) {
             log.info("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/petgoorm/backend/service/MemberServiceImpl.java
+++ b/src/main/java/com/petgoorm/backend/service/MemberServiceImpl.java
@@ -4,10 +4,13 @@ import com.petgoorm.backend.dto.ResponseDTO;
 import com.petgoorm.backend.dto.member.MemberRequestDTO;
 import com.petgoorm.backend.dto.member.MemberResponseDTO;
 import com.petgoorm.backend.entity.Member;
+import com.petgoorm.backend.handler.CustomException;
+import com.petgoorm.backend.handler.ErrorCode;
 import com.petgoorm.backend.jwt.JwtTokenProvider;
 import com.petgoorm.backend.repository.MemberRepository;
 import com.petgoorm.backend.repository.PetRepository;
 import com.petgoorm.backend.util.SecurityUtil;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -27,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 @Log4j2
 @Transactional
 @RequiredArgsConstructor
-public class MemberServiceImpl implements MemberService{
+public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
     private final PetRepository petRepository;
     private final PasswordEncoder passwordEncoder;
@@ -40,18 +43,18 @@ public class MemberServiceImpl implements MemberService{
     @Transactional
     public ResponseDTO<Long> signup(MemberRequestDTO.SignUp memberRequestDTO) {
         if (memberRepository.existsByEmail(memberRequestDTO.getEmail())) {
-            return ResponseDTO.of(HttpStatus.CONFLICT.value(),"이미 가입되어 있는 유저입니다",null);
+            return ResponseDTO.of(HttpStatus.CONFLICT.value(), "이미 가입되어 있는 유저입니다", null);
         }
         Member member = toEntity(passwordEncoder, memberRequestDTO);
         memberRepository.save(member);
-        return ResponseDTO.of(HttpStatus.OK.value(),"회원가입이 성공했습니다.",member.getId());
+        return ResponseDTO.of(HttpStatus.OK.value(), "회원가입이 성공했습니다.", member.getId());
 
     }
 
     //이메일 중복체크
     @Override
     @Transactional(readOnly = true)
-    public ResponseDTO<String> checkEmailDuplication(String email){
+    public ResponseDTO<String> checkEmailDuplication(String email) {
         boolean emailDuplicate = memberRepository.existsByEmail(email);
         log.info("중복체크 이메일: " + emailDuplicate);
         try {
@@ -63,7 +66,7 @@ public class MemberServiceImpl implements MemberService{
                 log.info("사용 가능한 이메일: " + email);
                 return ResponseDTO.of(HttpStatus.OK.value(), "사용 가능한 이메일입니다.", email);
             }
-        }catch (Exception e){
+        } catch (Exception e) {
             return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
         }
     }
@@ -77,14 +80,14 @@ public class MemberServiceImpl implements MemberService{
         try {
             if (nicknameDuplicate) {
                 //중복
-                log.info("중복 닉네임: "+nickname);
+                log.info("중복 닉네임: " + nickname);
                 return ResponseDTO.of(HttpStatus.CONFLICT.value(), "이미 존재하는 닉네임입니다.", null);
             } else {
                 //사용가능한 이메일
-                log.info("사용 가능한 닉네임: "+nickname);
+                log.info("사용 가능한 닉네임: " + nickname);
                 return ResponseDTO.of(HttpStatus.OK.value(), "사용 가능한 닉네임입니다.", nickname);
             }
-        }catch (Exception e){
+        } catch (Exception e) {
             return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
         }
     }
@@ -103,15 +106,15 @@ public class MemberServiceImpl implements MemberService{
             // 1. Login ID/PW 를 기반으로 Authentication 객체 생성
             // 이때 authentication 는 인증 여부를 확인하는 authenticated 값이 false
             UsernamePasswordAuthenticationToken authenticationToken = login.toAuthentication();
-            log.info("1. authenticationToken : "+authenticationToken);
+            log.info("1. authenticationToken : " + authenticationToken);
             // 2. 실제 검증 (사용자 비밀번호 체크)이 이루어지는 부분
             // authenticate 매서드가 실행될 때 CustomUserDetailsService 에서 만든 loadUserByUsername 메서드가 실행
             Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-            log.info("2. authentication : "+authentication);
+            log.info("2. authentication : " + authentication);
 
             // 3. 인증 정보를 기반으로 JWT 토큰 생성
             MemberResponseDTO.TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
-            log.info("3. tokenInfo : "+tokenInfo);
+            log.info("3. tokenInfo : " + tokenInfo);
 
             // 4. RefreshToken Redis 저장 (expirationTime 설정을 통해 자동 삭제 처리)
             // getName = 사용자의 이메일
@@ -119,7 +122,7 @@ public class MemberServiceImpl implements MemberService{
                     .set("RT:" + authentication.getName(), tokenInfo.getRefreshToken(), tokenInfo.getRefreshTokenExpirationTime(), TimeUnit.MILLISECONDS);
             log.info("4. redis 저장");
             return ResponseDTO.of(HttpStatus.OK.value(), "로그인에 성공했습니다.", tokenInfo);
-        }catch (Exception e){
+        } catch (Exception e) {
             e.printStackTrace();
             return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
         }
@@ -129,28 +132,36 @@ public class MemberServiceImpl implements MemberService{
     //refresh token 유효성 검증 후 access token 재발급
     @Override
     public ResponseDTO<String> reissue(String nowAccessToken) {
-        // 1. Access Token 에서 User email 을 가져옵니다.
-        Authentication authentication = jwtTokenProvider.getAuthentication(nowAccessToken);
+        try {
+            log.info("reissue service단 accesstoken: "+nowAccessToken);
+            // 1. Access Token 에서 User email 을 가져옵니다.
+            Authentication authentication = jwtTokenProvider.getAuthentication(nowAccessToken);
 
-        // 2. Redis 에서 User email 을 기반으로 저장된 Refresh Token 값을 가져옵니다.
-        String refreshToken = (String)redisTemplate.opsForValue().get("RT:" + authentication.getName());
+            // 2. Redis 에서 User email 을 기반으로 저장된 Refresh Token 값을 가져옵니다.
+            String refreshToken = (String) redisTemplate.opsForValue().get("RT:" + authentication.getName());
 
-        // 3. Refresh Token 검증
-        if (!jwtTokenProvider.validateToken(refreshToken)) {
-            return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Refresh Token 정보가 유효하지 않습니다.", null);
+            // 3. Refresh Token 검증
+            if (!jwtTokenProvider.validateToken(refreshToken)) {
+                log.info("refresh 토큰이 잘못되었습니다.");
+                //CustomException 사용한 예시 1
+                throw new CustomException(ErrorCode.JWT_REFRESH_TOKEN_EXPIRED);
+            }
+
+            // (추가) 로그아웃되어 Redis 에 RefreshToken 이 존재하지 않는 경우 처리
+            if (ObjectUtils.isEmpty(refreshToken)) {
+                log.info("로그아웃되어 refresh 토큰 존재하지 않음");
+                throw new CustomException(ErrorCode.JWT_REFRESH_TOKEN_EXPIRED);
+
+            }
+
+            // 4. 새로운 access 토큰 생성
+            String accessToken = jwtTokenProvider.accessToken(authentication);
+            log.info("reissue: 새로운 accesstoken 발급완료: " + accessToken);
+            return ResponseDTO.of(HttpStatus.OK.value(), "Token 정보가 갱신되었습니다.", accessToken);
+        } catch(ExpiredJwtException e) {
+            throw new CustomException(ErrorCode.JWT_REFRESH_TOKEN_EXPIRED);
         }
-
-        // (추가) 로그아웃되어 Redis 에 RefreshToken 이 존재하지 않는 경우 처리
-        if(ObjectUtils.isEmpty(refreshToken)) {
-            return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "잘못된 요청입니다", null);
-        }
-
-        // 4. 새로운 access 토큰 생성
-        String accessToken = jwtTokenProvider.accessToken(authentication);
-
-        return ResponseDTO.of(HttpStatus.OK.value(), "Token 정보가 갱신되었습니다.", accessToken);
     }
-
 
 
     @Transactional
@@ -186,22 +197,21 @@ public class MemberServiceImpl implements MemberService{
     //비밀번호 변경 서비스
     @Transactional
     @Override
-    public ResponseDTO<Long> updatePassword(MemberRequestDTO.UpdatePassword updatePassword){
+    public ResponseDTO<Long> updatePassword(MemberRequestDTO.UpdatePassword updatePassword) {
         // 현재 로그인한 사용자의 Member 정보 가져오기
         Member member = memberRepository.findByEmail(SecurityUtil.getCurrentUserEmail())
                 .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저를 찾을 수 없습니다."));
 
-        try{
+        try {
             boolean pwcheck = passwordEncoder.matches(updatePassword.getNowPW(), member.getPassword());
 
-            if(pwcheck){
+            if (pwcheck) {
                 member.updatePassword(passwordEncoder.encode(updatePassword.getUpdatePW()));
                 return ResponseDTO.of(HttpStatus.OK.value(), "비밀번호 변경에 성공했습니다.", member.getId());
             }
             return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "비밀번호가 올바르지 않습니다", null);
 
-        }
-        catch (Exception e){
+        } catch (Exception e) {
             return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
         }
 
@@ -212,17 +222,15 @@ public class MemberServiceImpl implements MemberService{
     //닉네임 변경 서비스
     @Transactional
     @Override
-    public ResponseDTO<Long> updateNick(MemberRequestDTO.UpdateNick updateNick){
+    public ResponseDTO<Long> updateNick(MemberRequestDTO.UpdateNick updateNick) {
         // 현재 로그인한 사용자의 Member 정보 가져오기
         Member member = memberRepository.findByEmail(SecurityUtil.getCurrentUserEmail())
                 .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저를 찾을 수 없습니다."));
 
-        try{
-                member.updateNick(updateNick.getNickname());
-                return ResponseDTO.of(HttpStatus.OK.value(), "닉네임 변경에 성공했습니다.", member.getId());
-        }
-
-        catch (Exception e){
+        try {
+            member.updateNick(updateNick.getNickname());
+            return ResponseDTO.of(HttpStatus.OK.value(), "닉네임 변경에 성공했습니다.", member.getId());
+        } catch (Exception e) {
             return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
         }
 
@@ -231,18 +239,16 @@ public class MemberServiceImpl implements MemberService{
     //회원 탈퇴 서비스
     @Transactional
     @Override
-    public ResponseDTO<Long> deleteMember(){
+    public ResponseDTO<Long> deleteMember() {
         // 현재 로그인한 사용자의 Member 정보 가져오기
         Member member = memberRepository.findByEmail(SecurityUtil.getCurrentUserEmail())
                 .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저를 찾을 수 없습니다."));
 
-        try{
+        try {
             petRepository.deletePetByMemberId(member.getId());
             memberRepository.deleteMemberByEmail(member.getEmail());
             return ResponseDTO.of(HttpStatus.OK.value(), "회원 탈퇴에 성공했습니다.", member.getId());
-        }
-
-        catch (Exception e){
+        } catch (Exception e) {
             return ResponseDTO.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "예기치 못한 에러가 발생했습니다.", null);
         }
 

--- a/src/main/java/com/petgoorm/backend/service/ReplyServiceImpl.java
+++ b/src/main/java/com/petgoorm/backend/service/ReplyServiceImpl.java
@@ -7,6 +7,8 @@ import com.petgoorm.backend.dto.board.BoardResponseDTO;
 import com.petgoorm.backend.entity.Board;
 import com.petgoorm.backend.entity.Member;
 import com.petgoorm.backend.entity.Reply;
+import com.petgoorm.backend.handler.CustomException;
+import com.petgoorm.backend.handler.ErrorCode;
 import com.petgoorm.backend.repository.BoardRepository;
 import com.petgoorm.backend.repository.MemberRepository;
 import com.petgoorm.backend.repository.ReplyRepository;
@@ -96,6 +98,10 @@ public class ReplyServiceImpl implements ReplyService {
                 .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저를 찾을 수 없습니다."));
 
         Optional<Board> opBoard = boardRepository.findById(boardId);
+
+        //게시글이 존재하지 않는다면 customexception 발생
+        //CustomException 사용한 예시 2
+        opBoard.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
 
         List<BoardResponseDTO.Reply> replyDTOList = new ArrayList<>();
 


### PR DESCRIPTION
**1. spring security 필터 단에서 발생하는 인증 인가 에러를 핸들링 해주는 클래스 생성**
- `CustomAccessDeniedHandler` : 인가 에러를 핸들링하는 클래스, 무조건 FORBIDDEN에러 반환
- `CustomAuthenticationEntryPoint` : 인증 에러를 핸들링하는 클래스, 무조건 UNAUTHORIZATION에러 반환

**2. spring security 필터 단에서 access 토큰 만료 Exception이 발생시 특정 에러코드(5001)를 클라이언트에 반환하여 새로 access token을 발급받는 기능 추가**
- `JwtAuthenticationFilter` 내에 `setErrorReponse` 메서드를 활용하여 특정 에러코드 반환
- ExpireExption은 인증 에러지만 필터 내에서 catch하여 처리하도록 되어있기때문에 `CustomAuthenticationEntryPoint`로 처리되지 않음.

**3. 컨트롤러 단에서 발생하는 Exception에러를 핸들링해주는 Custom 클래스 생성**
- `@RestControllerAdvice`를 붙이면 Exception에러를 감지할 수 있음 -
-  `ExceptionHandler`클래스 : `CustomException` 클래스를 감지하여 핸들링하도록 함
- 사용예시 
- Optional 이용:  `opBoard.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));`
- throw문 이용: `throw new CustomException(ErrorCode.JWT_REFRESH_TOKEN_EXPIRED);`